### PR TITLE
Simplify CellFragment predicate in SortCells

### DIFF
--- a/kernel/src/test/java/org/kframework/kore/compile/SortCellsTest.java
+++ b/kernel/src/test/java/org/kframework/kore/compile/SortCellsTest.java
@@ -3,11 +3,13 @@ package org.kframework.kore.compile;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.kframework.builtin.BooleanUtils;
 import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Labels;
 import org.kframework.builtin.Sorts;
 import org.kframework.compile.ConfigurationInfo;
 import org.kframework.compile.LabelInfo;
+import org.kframework.definition.Rule;
 import org.kframework.kil.Attribute;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
@@ -230,7 +232,45 @@ public class SortCellsTest {
         Assert.assertEquals(0, kem.getExceptions().size());
     }
 
+    /** When a cell fragment variable occurs as an argument to the appropriate cell fragment sort predict, we
+     * specialize the expansion by splitting it into a conjunction of individual sort predicate tests on
+     * the variables the cell fragment variable splits into, rather than just using the generic replacement term.
+     * This is a very special case of statically simplifying predicate applications.
+     */
+    @Test
+    public void testPredicateExpansion() {
+        Rule term = new Rule(KRewrite(cell("<t>", cell("<env>"), KVariable("X"), KVariable("Y", Att().add(Attribute.SORT_KEY, "OptCell"))), KVariable("X"))
+                , app("isThreadCellFragment",KVariable("X"))
+                , BooleanUtils.TRUE
+                , Att());
+        K expectedBody = KRewrite(cell("<t>", KVariable("X"), cell("<env>"), KVariable("Y", Att().add(Attribute.SORT_KEY, "OptCell"))),
+                cell("<t>-fragment", KVariable("X"), app("noEnvCell"), app("noOptCell")));
+        Rule expected = new Rule(expectedBody
+                , BooleanUtils.and(BooleanUtils.TRUE, app("isKCell", KVariable("X")))
+                , BooleanUtils.TRUE, Att());
+        KExceptionManager kem = new KExceptionManager(new GlobalOptions());
+        Assert.assertEquals(expected, new SortCells(cfgInfo, labelInfo, kem).sortCells(term));
+        Assert.assertEquals(0, kem.getExceptions().size());
+    }
 
+    /** Check that the splitting in {@linkplain #testPredicateExpansion()} doesn't happen with
+     *
+     */
+    @Test
+    public void testUnrelatedPredicate() {
+        Rule term = new Rule(KRewrite(cell("<t>", cell("<env>"), KVariable("X"), KVariable("Y", Att().add(Attribute.SORT_KEY, "OptCell"))), KVariable("X"))
+                , app("isTopCellFragment",KVariable("X"))
+                , BooleanUtils.TRUE
+                , Att());
+        K replacement = app("<t>-fragment", KVariable("X"), app("noEnvCell"), app("noOptCell"));
+        K expectedBody = KRewrite(cell("<t>", KVariable("X"), cell("<env>"), KVariable("Y", Att().add(Attribute.SORT_KEY, "OptCell"))), replacement);
+        Rule expected = new Rule(expectedBody
+                , app("isTopCellFragment", replacement)
+                , BooleanUtils.TRUE, Att());
+        KExceptionManager kem = new KExceptionManager(new GlobalOptions());
+        Assert.assertEquals(expected, new SortCells(cfgInfo, labelInfo, kem).sortCells(term));
+        Assert.assertEquals(0, kem.getExceptions().size());
+    }
 
     KApply app(String name, K... ks) {
         return KApply(KLabel(name), ks);


### PR DESCRIPTION
This commit extends the SortCells pass to simplify applications of
the corresponding cell fragment sort predicate to a cell fragment variable
into calls of the apropriate sort predicates on the individual split variables,
and also removes any special handling of isBag calls, as the Bag
sort no longer has any particular relationship to cell fragment sorts.
