### PR TITLE
Drop isBag warning.

### DIFF
--- a/kernel/src/main/java/org/kframework/kore/compile/SortCells.java
+++ b/kernel/src/main/java/org/kframework/kore/compile/SortCells.java
@@ -358,7 +358,6 @@ public class SortCells {
                         KVariable var = (KVariable)k.klist().items().get(0);
                         VarInfo info = variables.get(var);
                         if (info != null) {
-                            kem.registerCompilerWarning("Accepting deprecated use of isBag as predicate for a cell fragment", k);
                             return info.getSplit(var).entrySet().stream()
                                     .map(e -> (K) KApply(KLabel("is" + getPredicateSort(e.getKey())), e.getValue()))
                                     .reduce(BooleanUtils.TRUE, BooleanUtils::and);


### PR DESCRIPTION
mvn verify considers any warnings as errors.

Also, the front-end grammar uses "Bag" as the name of
unsorted collections of cells, so it's hard to avoid ending up
with variables of inferred sort Bag (especially the wildcard
variables produced from dots).
